### PR TITLE
fix(readmore): prevent auto-collapsing readmore

### DIFF
--- a/views/default/river/readmore.js
+++ b/views/default/river/readmore.js
@@ -5,12 +5,14 @@ define(function (require) {
 
 	var readmore = {
 		init: function () {
-			$('.elgg-river-message,.interactions-comment-body').readmore({
-				speed: 75,
-				collapsedHeight: 150,
-				lessLink: '<a class="river-read-less" href="#">' + elgg.echo('river:read:less') + '</a>',
-				moreLink: '<a class="river-read-more" href="#">' + elgg.echo('river:read:more') + '</a>',
-			});
+			$('.elgg-river-message:not([data-readmore]),.interactions-comment-body:not([data-readmore])')
+				.css('overflow', 'hidden')
+				.readmore({
+					speed: 75,
+					collapsedHeight: 150,
+					lessLink: '<a class="river-read-less" href="#">' + elgg.echo('river:read:less') + '</a>',
+					moreLink: '<a class="river-read-more" href="#">' + elgg.echo('river:read:more') + '</a>',
+				});
 		}
 	};
 


### PR DESCRIPTION
Due to repeated initialization of the readmore js when .elgg-list changes an open section could automagically close while someone is reading.  This makes the jquery selectors more specific so an existing element isn't re-initialized.