### PR TITLE
chore(feed): set first-tab as default on activity

### DIFF
--- a/classes/hypeJunction/Feed/Router.php
+++ b/classes/hypeJunction/Feed/Router.php
@@ -15,6 +15,12 @@ class Router {
 
 		$page = array_shift($segments);
 
+		if (!$page) {
+			$tabs = Config::getTabs(true);
+			$main_tab = array_pop(array_reverse($tabs));
+			$page = $main_tab->getName();
+		}
+
 		switch ($page) {
 			default :
 			case 'all' :


### PR DESCRIPTION
Expected behavior when loads 'Activity' view and your first or default tab isn't 'All'.